### PR TITLE
solve error if path not contain directory

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -26,7 +26,8 @@ def load_pickle(path):
 
 
 def write_pickle(o, path):
-  tf.gfile.MakeDirs(path.rsplit('/', 1)[0])
+  if '/' in path:
+    tf.gfile.MakeDirs(path.rsplit('/', 1)[0])
   with tf.gfile.GFile(path, 'wb') as f:
     pickle.dump(o, f, -1)
 


### PR DESCRIPTION
Solve error if path does not contain a directory

```
Traceback (most recent call last):
  File "extract_attention.py", line 144, in <module>
    main()
  File "extract_attention.py", line 139, in main
    utils.write_pickle(feature_dicts_with_attn, outpath)
  File "/Users/smap10/Project/attention-analysis-master/utils.py", line 31, in write_pickle
    pickle.dump(o, f, -1)
  File "/anaconda3/envs/tf/lib/python3.6/site-packages/tensorflow/python/lib/io/file_io.py", line 106, in write
    self._prewrite_check()
  File "/anaconda3/envs/tf/lib/python3.6/site-packages/tensorflow/python/lib/io/file_io.py", line 92, in _prewrite_check
    compat.as_bytes(self.__name), compat.as_bytes(self.__mode))
tensorflow.python.framework.errors_impl.FailedPreconditionError: samples_10_no_text_attn.pkl; Is a directory
```
