### PR TITLE
Fix pickle unicode error

### DIFF
--- a/General_Analysis.ipynb
+++ b/General_Analysis.ipynb
@@ -46,7 +46,7 @@
    "source": [
     "def load_pickle(fname):\n",
     "    with open(fname, \"rb\") as f:\n",
-    "        return pickle.load(f)  # add, encoding=\"latin1\") if using python3 and downloaded data\n",
+    "        return pickle.load(f, encoding='latin1')  # add, encoding=\"latin1\") if using python3 and downloaded data\n",
     "\n",
     "# BERT-base Attention Maps extracted from Wikipedia\n",
     "# Data is a list of dicts of the followig form:\n",

--- a/Syntax_Analysis.ipynb
+++ b/Syntax_Analysis.ipynb
@@ -50,7 +50,7 @@
    "source": [
     "def load_pickle(fname):\n",
     "  with open(fname, \"rb\") as f:\n",
-    "    return pickle.load(f)  # add, encoding=\"latin1\") if using python3 and downloaded data\n",
+    "    return pickle.load(f, encoding='latin1')  # add, encoding=\"latin1\") if using python3 and downloaded data\n",
     "    \n",
     "dev_data = load_pickle(\"./data/depparse/dev_attn.pkl\")\n",
     "\n",


### PR DESCRIPTION
- error message: 
`'ascii' codec can't decode byte 0x84 in position 0: ordinal not in range(128)`
- ref: https://stackoverflow.com/questions/11305790/pickle-incompatibility-of-numpy-arrays-between-python-2-and-3